### PR TITLE
[Feature/refactor] modularization API request logic and refactor project architecture

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,9 @@
 import { Global } from '@emotion/react';
 import { ThemeProvider } from '@contexts/ThemeContext';
-import Header from '@components/Header/Header';
-import Layout from '@components/Layout/Layout';
-import Banner from '@components/Banner/Banner';
-import ArticleList from '@components/ArticleList/ArticleList';
+import { Header } from '@components/Header';
+import { Layout } from '@components/Layout';
+import { Banner } from '@components/Banner';
+import { ArticleList } from '@components/ArticleList';
 import globalStyle from '@styles/global';
 
 function App() {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,10 @@
 import { Global } from '@emotion/react';
-import { ThemeProvider } from './contexts/ThemeContext';
-import Header from './components/Header/Header';
-import Layout from './components/Layout/Layout';
-import Banner from './components/Banner/Banner';
-import ArticleList from './components/ArticleList/ArticleList';
-import globalStyle from './styles/global';
+import { ThemeProvider } from '@contexts/ThemeContext';
+import Header from '@components/Header/Header';
+import Layout from '@components/Layout/Layout';
+import Banner from '@components/Banner/Banner';
+import ArticleList from '@components/ArticleList/ArticleList';
+import globalStyle from '@styles/global';
 
 function App() {
   return (

--- a/src/apis/axios.js
+++ b/src/apis/axios.js
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { BASE_URL } from '../constants/api';
+
+export const axiosNYT = axios.create({
+  baseURL: BASE_URL.NYT,
+  params: {
+    'api-key': import.meta.env.VITE_NYT_API_KEY,
+  },
+});
+
+export const axiosGoogleTranslate = axios.create({
+  baseURL: BASE_URL.GOOGLE_TRANSLATE,
+  params: {
+    key: import.meta.env.VITE_GOOGLE_API_KEY,
+    target: 'ko',
+  },
+});
+
+axiosNYT.interceptors.response.use((response) => {
+  // 배너 기사
+  if (response.data.results) {
+    const randomNumber = Math.floor(
+      Math.random() * response.data.results.length
+    );
+    const article = response.data.results[randomNumber];
+    // 기사 section 이름의 첫 글자를 대문자로 변환(us인 경우 모든 글자를 대문자로 변환)
+    article.section = article.section.replace(/(\bus\b)|(\b\w)/g, (str) =>
+      str.toUpperCase()
+    );
+    return article;
+  }
+
+  // 메인 콘텐츠 기사 목록
+  else if (response.data.response) {
+    const articleList = response.data.response.docs;
+    return articleList;
+  }
+});
+
+axiosGoogleTranslate.interceptors.response.use((response) => {
+  const translatedText = response.data.data.translations[0].translatedText;
+  return translatedText;
+});

--- a/src/apis/axios.js
+++ b/src/apis/axios.js
@@ -33,6 +33,10 @@ axiosNYT.interceptors.response.use((response) => {
   // 메인 콘텐츠 기사 목록
   else if (response.data.response) {
     const articleList = response.data.response.docs;
+    // 기사 발행일을 yyyy-mm-dd 형식으로 변환
+    articleList.forEach(
+      (article) => (article.pub_date = article.pub_date.substring(0, 10))
+    );
     return articleList;
   }
 });

--- a/src/apis/axios.js
+++ b/src/apis/axios.js
@@ -1,10 +1,10 @@
 import axios from 'axios';
-import getRandomInt from '../utils/getRandomInt';
+import getRandomInt from '@utils/getRandomInt';
 import {
   formatPublishDate,
   capitalizeFirstLetter,
-} from '../utils/formattingText';
-import { BASE_URL } from '../constants/api';
+} from '@utils/formattingText';
+import { BASE_URL } from '@constants/api';
 
 export const axiosNYT = axios.create({
   baseURL: BASE_URL.NYT,

--- a/src/apis/axios.js
+++ b/src/apis/axios.js
@@ -1,4 +1,9 @@
 import axios from 'axios';
+import getRandomInt from '../utils/getRandomInt';
+import {
+  formatPublishDate,
+  capitalizeFirstLetter,
+} from '../utils/formattingText';
 import { BASE_URL } from '../constants/api';
 
 export const axiosNYT = axios.create({
@@ -19,24 +24,16 @@ export const axiosGoogleTranslate = axios.create({
 axiosNYT.interceptors.response.use((response) => {
   // 배너 기사
   if (response.data.results) {
-    const randomNumber = Math.floor(
-      Math.random() * response.data.results.length
-    );
-    const article = response.data.results[randomNumber];
-    // 기사 section 이름의 첫 글자를 대문자로 변환(us인 경우 모든 글자를 대문자로 변환)
-    article.section = article.section.replace(/(\bus\b)|(\b\w)/g, (str) =>
-      str.toUpperCase()
-    );
+    const randomInt = getRandomInt(response.data.results.length);
+    const article = response.data.results[randomInt]; // 응답 결과 기사 목록 중 랜덤한 기사 선택
+    article.section = capitalizeFirstLetter(article.section); // 기사 section 이름의 첫 글자 대문자화
     return article;
   }
 
   // 메인 콘텐츠 기사 목록
   else if (response.data.response) {
     const articleList = response.data.response.docs;
-    // 기사 발행일을 yyyy-mm-dd 형식으로 변환
-    articleList.forEach(
-      (article) => (article.pub_date = article.pub_date.substring(0, 10))
-    );
+    articleList.forEach((article) => formatPublishDate(article.pub_date)); // 기사 발행일을 yyyy-mm-dd 형식으로 변환
     return articleList;
   }
 });

--- a/src/components/ArticleList/Article.jsx
+++ b/src/components/ArticleList/Article.jsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
 import useTranslate from '@hooks/useTranslate';
 import Translation from '@common/Translation/Translation';

--- a/src/components/ArticleList/Article.jsx
+++ b/src/components/ArticleList/Article.jsx
@@ -1,7 +1,6 @@
 import { useTheme, css } from '@emotion/react';
 import useTranslate from '@hooks/useTranslate';
-import Translation from '@common/Translation/Translation';
-import TranslateButton from '@common/Button/TranslateButton';
+import { Translation, TranslateButton } from '@components/common';
 
 function Article({ publishDate, headline }) {
   const [

--- a/src/components/ArticleList/Article.jsx
+++ b/src/components/ArticleList/Article.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
-import useTranslate from '../../hooks/useTranslate';
-import Translation from '../common/Translation/Translation';
-import TranslateButton from '../common/Button/TranslateButton';
+import useTranslate from '@hooks/useTranslate';
+import Translation from '@common/Translation/Translation';
+import TranslateButton from '@common/Button/TranslateButton';
 
 function Article({ publishDate, headline }) {
   const [

--- a/src/components/ArticleList/Article.jsx
+++ b/src/components/ArticleList/Article.jsx
@@ -1,39 +1,22 @@
 import { useState } from 'react';
 import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
+import useTranslate from '../../hooks/useTranslate';
 import Translation from '../common/Translation/Translation';
 import TranslateButton from '../common/Button/TranslateButton';
 
 function Article({ publishDate, headline }) {
-  const [isTranslated, setIsTranslated] = useState(false);
-  const [isTranslateLoading, setIsTranslateLoading] = useState(false);
-  const [translateError, setTranslateError] = useState(null);
-  const [translationText, setTranslationText] = useState(null);
+  const [
+    isTranslated,
+    isTranslateLoading,
+    translateError,
+    translationText,
+    translate,
+  ] = useTranslate();
 
   const theme = useTheme();
 
   const formattedPublishDate = publishDate.substring(0, 10);
-
-  const translate = async () => {
-    if (!translationText) {
-      setIsTranslateLoading(true);
-      try {
-        const response = await axios.post(
-          `https://translation.googleapis.com/language/translate/v2?&key=${import.meta.env.VITE_GOOGLE_API_KEY}`,
-          { q: headline, target: 'ko' }
-        );
-        setTranslationText(response.data.data.translations[0].translatedText);
-        setIsTranslated(!isTranslated);
-      } catch (error) {
-        console.log(`기사 번역 중 오류 발생 | ${error}`);
-        setTranslateError(error);
-      }
-      setIsTranslateLoading(false);
-    } else {
-      // 이미 저장된 번역문이 있는 경우 API 재요청을 방지하고 토글 기능만 실행
-      setIsTranslated(!isTranslated);
-    }
-  };
 
   return (
     <article
@@ -83,7 +66,11 @@ function Article({ publishDate, headline }) {
           color: ${theme.color.emphasis.secondary};
         `}
       >
-        <TranslateButton isTranslated={isTranslated} translate={translate} />
+        <TranslateButton
+          headline={headline}
+          isTranslated={isTranslated}
+          translate={translate}
+        />
       </div>
     </article>
   );

--- a/src/components/ArticleList/ArticleList.jsx
+++ b/src/components/ArticleList/ArticleList.jsx
@@ -1,10 +1,10 @@
 import Masonry from 'react-masonry-css';
 import { css } from '@emotion/react';
-import useFetchData from '../../hooks/useFetchData';
-import { NYT_REQUEST_URL } from '../../constants/api';
-import LoadingMessage from '../common/Loading/LoadingMessage';
-import ErrorMessage from '../common/Error/ErrorMessage';
-import Article from './Article';
+import useFetchData from '@hooks/useFetchData';
+import { NYT_REQUEST_URL } from '@constants/api';
+import LoadingMessage from '@common/Loading/LoadingMessage';
+import ErrorMessage from '@common/Error/ErrorMessage';
+import Article from '@components/ArticleList/Article';
 
 function ArticleList() {
   const [isFetchLoading, fetchError, articleList] = useFetchData(

--- a/src/components/ArticleList/ArticleList.jsx
+++ b/src/components/ArticleList/ArticleList.jsx
@@ -12,37 +12,36 @@ function ArticleList() {
 
   if (isFetchLoading) return <LoadingMessage type={'유용한'} />;
   if (fetchError) return <ErrorMessage />;
+  if (!articleList) return null;
 
   return (
     <>
-      {articleList && (
-        <div
+      <div
+        css={css`
+          padding: 24px 0;
+        `}
+      >
+        <Masonry
+          breakpointCols={2}
           css={css`
-            padding: 24px 0;
+            display: flex;
+            > *:not(:last-child) {
+              margin-right: 24px;
+            }
+            > * > *:not(:last-child) {
+              margin-bottom: 24px;
+            }
           `}
         >
-          <Masonry
-            breakpointCols={2}
-            css={css`
-              display: flex;
-              > *:not(:last-child) {
-                margin-right: 24px;
-              }
-              > * > *:not(:last-child) {
-                margin-bottom: 24px;
-              }
-            `}
-          >
-            {articleList.map((article) => (
-              <Article
-                key={article._id}
-                publishDate={article.pub_date}
-                headline={article.headline.main}
-              />
-            ))}
-          </Masonry>
-        </div>
-      )}
+          {articleList.map((article) => (
+            <Article
+              key={article._id}
+              publishDate={article.pub_date}
+              headline={article.headline.main}
+            />
+          ))}
+        </Masonry>
+      </div>
     </>
   );
 }

--- a/src/components/ArticleList/ArticleList.jsx
+++ b/src/components/ArticleList/ArticleList.jsx
@@ -1,32 +1,15 @@
-import { useState, useEffect } from 'react';
-import axios from 'axios';
 import Masonry from 'react-masonry-css';
 import { css } from '@emotion/react';
+import useFetchData from '../../hooks/useFetchData';
+import { NYT_REQUEST_URL } from '../../constants/api';
 import LoadingMessage from '../common/Loading/LoadingMessage';
 import ErrorMessage from '../common/Error/ErrorMessage';
 import Article from './Article';
 
 function ArticleList() {
-  const [isFetchLoading, setIsFetchLoading] = useState(false);
-  const [fetchError, setFetchError] = useState(null);
-  const [articleList, setArticleList] = useState(null);
-
-  useEffect(() => {
-    const fetchArticleList = async () => {
-      setIsFetchLoading(true);
-      try {
-        const response = await axios.get(
-          `https://api.nytimes.com/svc/search/v2/articlesearch.json?api-key=${import.meta.env.VITE_NYT_API_KEY}`
-        );
-        setArticleList(response.data.response.docs);
-      } catch (error) {
-        console.log(`기사 조회 중 오류 발생 | ${error}`);
-        setFetchError(error);
-      }
-      setIsFetchLoading(false);
-    };
-    fetchArticleList();
-  }, []);
+  const [isFetchLoading, fetchError, articleList] = useFetchData(
+    NYT_REQUEST_URL.SEARCH
+  );
 
   if (isFetchLoading) return <LoadingMessage type={'유용한'} />;
   if (fetchError) return <ErrorMessage />;

--- a/src/components/ArticleList/ArticleList.jsx
+++ b/src/components/ArticleList/ArticleList.jsx
@@ -2,9 +2,8 @@ import Masonry from 'react-masonry-css';
 import { css } from '@emotion/react';
 import useFetchData from '@hooks/useFetchData';
 import { NYT_REQUEST_URL } from '@constants/api';
-import LoadingMessage from '@common/Loading/LoadingMessage';
-import ErrorMessage from '@common/Error/ErrorMessage';
-import Article from '@components/ArticleList/Article';
+import { LoadingMessage, ErrorMessage } from '@components/common';
+import { Article } from '@components/ArticleList';
 
 function ArticleList() {
   const [isFetchLoading, fetchError, articleList] = useFetchData(

--- a/src/components/ArticleList/index.js
+++ b/src/components/ArticleList/index.js
@@ -1,0 +1,4 @@
+import Article from './Article';
+import ArticleList from './ArticleList';
+
+export { Article, ArticleList };

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,6 +1,6 @@
 import { useTheme, css } from '@emotion/react';
-import BannerHeader from './BannerHeader';
-import BannerArticle from './BannerArticle';
+import BannerHeader from '@components/Banner/BannerHeader';
+import BannerArticle from '@components/Banner/BannerArticle';
 
 function Banner() {
   const theme = useTheme();

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,6 +1,5 @@
 import { useTheme, css } from '@emotion/react';
-import BannerHeader from '@components/Banner/BannerHeader';
-import BannerArticle from '@components/Banner/BannerArticle';
+import { BannerHeader, BannerArticle } from '@components/Banner';
 
 function Banner() {
   const theme = useTheme();

--- a/src/components/Banner/BannerArticle.jsx
+++ b/src/components/Banner/BannerArticle.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
 import useFetchData from '../../hooks/useFetchData';
+import useTranslate from '../../hooks/useTranslate';
 import { NYT_REQUEST_URL } from '../../constants/api';
 import LoadingMessage from '../common/Loading/LoadingMessage';
 import ErrorMessage from '../common/Error/ErrorMessage';
@@ -13,34 +14,15 @@ function BannerArticle() {
   const [isFetchLoading, fetchError, article] = useFetchData(
     NYT_REQUEST_URL.TOP_STORIES
   );
-
-  const [isTranslated, setIsTranslated] = useState(false);
-  const [isTranslateLoading, setIsTranslateLoading] = useState(false);
-  const [translateError, setTranslateError] = useState(null);
-  const [translationText, setTranslationText] = useState(null);
+  const [
+    isTranslated,
+    isTranslateLoading,
+    translateError,
+    translationText,
+    translate,
+  ] = useTranslate();
 
   const theme = useTheme();
-
-  const translate = async () => {
-    if (!isTranslated) {
-      setIsTranslateLoading(true);
-      try {
-        const response = await axios.post(
-          `https://translation.googleapis.com/language/translate/v2?&key=${import.meta.env.VITE_GOOGLE_API_KEY}`,
-          { q: article.title, target: 'ko' }
-        );
-        setTranslationText(response.data.data.translations[0].translatedText);
-        setIsTranslated(!isTranslated);
-      } catch (error) {
-        console.log(`기사 번역 중 오류 발생 | ${error}`);
-        setTranslateError(error);
-      }
-      setIsTranslateLoading(false);
-    } else {
-      // 이미 저장된 번역문이 있는 경우 API 재요청을 방지하고 토글 기능만 실행
-      setIsTranslated(!isTranslated);
-    }
-  };
 
   if (isFetchLoading) return <LoadingMessage type={'화제가 된'} />;
   if (fetchError) return <ErrorMessage />;
@@ -81,7 +63,11 @@ function BannerArticle() {
           ${theme.typography.bannerButton}
         `}
       >
-        <TranslateButton isTranslated={isTranslated} translate={translate} />
+        <TranslateButton
+          headline={article && article.title}
+          isTranslated={isTranslated}
+          translate={translate}
+        />
         <ArticleLinkButton articleLink={article && article.url} />
       </div>
     </>

--- a/src/components/Banner/BannerArticle.jsx
+++ b/src/components/Banner/BannerArticle.jsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
 import useFetchData from '@hooks/useFetchData';
 import useTranslate from '@hooks/useTranslate';

--- a/src/components/Banner/BannerArticle.jsx
+++ b/src/components/Banner/BannerArticle.jsx
@@ -2,11 +2,13 @@ import { useTheme, css } from '@emotion/react';
 import useFetchData from '@hooks/useFetchData';
 import useTranslate from '@hooks/useTranslate';
 import { NYT_REQUEST_URL } from '@constants/api';
-import LoadingMessage from '@common/Loading/LoadingMessage';
-import ErrorMessage from '@common/Error/ErrorMessage';
-import Translation from '@common/Translation/Translation';
-import TranslateButton from '@common/Button/TranslateButton';
-import ArticleLinkButton from '@common/Button/ArticleLinkButton';
+import {
+  LoadingMessage,
+  ErrorMessage,
+  Translation,
+  TranslateButton,
+  ArticleLinkButton,
+} from '@components/common';
 
 function BannerArticle() {
   const [isFetchLoading, fetchError, article] = useFetchData(

--- a/src/components/Banner/BannerArticle.jsx
+++ b/src/components/Banner/BannerArticle.jsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
+import useFetchData from '../../hooks/useFetchData';
+import { NYT_REQUEST_URL } from '../../constants/api';
 import LoadingMessage from '../common/Loading/LoadingMessage';
 import ErrorMessage from '../common/Error/ErrorMessage';
 import Translation from '../common/Translation/Translation';
@@ -8,9 +10,9 @@ import TranslateButton from '../common/Button/TranslateButton';
 import ArticleLinkButton from '../common/Button/ArticleLinkButton';
 
 function BannerArticle() {
-  const [isFetchLoading, setIsFetchLoading] = useState(false);
-  const [fetchError, setFetchError] = useState(null);
-  const [article, setArticle] = useState(null);
+  const [isFetchLoading, fetchError, article] = useFetchData(
+    NYT_REQUEST_URL.TOP_STORIES
+  );
 
   const [isTranslated, setIsTranslated] = useState(false);
   const [isTranslateLoading, setIsTranslateLoading] = useState(false);
@@ -39,32 +41,6 @@ function BannerArticle() {
       setIsTranslated(!isTranslated);
     }
   };
-
-  useEffect(() => {
-    const fetchArticle = async () => {
-      setIsFetchLoading(true);
-      try {
-        const response = await axios.get(
-          `https://api.nytimes.com/svc/topstories/v2/home.json?api-key=${import.meta.env.VITE_NYT_API_KEY}`
-        );
-        const randomNum = Math.floor(
-          Math.random() * response.data.results.length
-        );
-        const article = response.data.results[randomNum];
-
-        // 기사 section 이름의 첫 글자를 대문자로 변환(us인 경우 모든 글자를 대문자로 변환)
-        article.section = article.section.replace(/(\bus\b)|(\b\w)/g, (str) =>
-          str.toUpperCase()
-        );
-        setArticle(article);
-      } catch (error) {
-        console.log(`기사 조회 중 오류 발생 | ${error}`);
-        setFetchError(error);
-      }
-      setIsFetchLoading(false);
-    };
-    fetchArticle();
-  }, []);
 
   if (isFetchLoading) return <LoadingMessage type={'화제가 된'} />;
   if (fetchError) return <ErrorMessage />;

--- a/src/components/Banner/BannerArticle.jsx
+++ b/src/components/Banner/BannerArticle.jsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import axios from 'axios';
 import { useTheme, css } from '@emotion/react';
-import useFetchData from '../../hooks/useFetchData';
-import useTranslate from '../../hooks/useTranslate';
-import { NYT_REQUEST_URL } from '../../constants/api';
-import LoadingMessage from '../common/Loading/LoadingMessage';
-import ErrorMessage from '../common/Error/ErrorMessage';
-import Translation from '../common/Translation/Translation';
-import TranslateButton from '../common/Button/TranslateButton';
-import ArticleLinkButton from '../common/Button/ArticleLinkButton';
+import useFetchData from '@hooks/useFetchData';
+import useTranslate from '@hooks/useTranslate';
+import { NYT_REQUEST_URL } from '@constants/api';
+import LoadingMessage from '@common/Loading/LoadingMessage';
+import ErrorMessage from '@common/Error/ErrorMessage';
+import Translation from '@common/Translation/Translation';
+import TranslateButton from '@common/Button/TranslateButton';
+import ArticleLinkButton from '@common/Button/ArticleLinkButton';
 
 function BannerArticle() {
   const [isFetchLoading, fetchError, article] = useFetchData(

--- a/src/components/Banner/BannerArticle.jsx
+++ b/src/components/Banner/BannerArticle.jsx
@@ -26,6 +26,7 @@ function BannerArticle() {
 
   if (isFetchLoading) return <LoadingMessage type={'화제가 된'} />;
   if (fetchError) return <ErrorMessage />;
+  if (!article) return null;
 
   return (
     <>
@@ -37,7 +38,7 @@ function BannerArticle() {
             ${theme.typography.bannerSection}
           `}
         >
-          {article && article.section}
+          {article.section}
         </span>
         <p
           css={css`
@@ -45,7 +46,7 @@ function BannerArticle() {
             ${theme.typography.bannerTitle}
           `}
         >
-          {article && article.title}
+          {article.title}
         </p>
         <Translation
           isTranslated={isTranslated}
@@ -64,11 +65,11 @@ function BannerArticle() {
         `}
       >
         <TranslateButton
-          headline={article && article.title}
+          headline={article.title}
           isTranslated={isTranslated}
           translate={translate}
         />
-        <ArticleLinkButton articleLink={article && article.url} />
+        <ArticleLinkButton articleLink={article.url} />
       </div>
     </>
   );

--- a/src/components/Banner/BannerHeader.jsx
+++ b/src/components/Banner/BannerHeader.jsx
@@ -1,8 +1,8 @@
 import { useTheme, css } from '@emotion/react';
-import { useThemeMode } from '../../contexts/ThemeContext';
-import { formatDateWithDayofWeek } from '../../utils/formattingText';
-import logoLight from '../../assets/logo-light.svg';
-import logoDark from '../../assets/logo-dark.svg';
+import { useThemeMode } from '@contexts/ThemeContext';
+import { formatDateWithDayofWeek } from '@utils/formattingText';
+import logoLight from '@assets/logo-light.svg';
+import logoDark from '@assets/logo-dark.svg';
 
 function BannerHeader() {
   const themeMode = useThemeMode();

--- a/src/components/Banner/BannerHeader.jsx
+++ b/src/components/Banner/BannerHeader.jsx
@@ -1,5 +1,6 @@
 import { useTheme, css } from '@emotion/react';
 import { useThemeMode } from '../../contexts/ThemeContext';
+import { formatDateWithDayofWeek } from '../../utils/formattingText';
 import logoLight from '../../assets/logo-light.svg';
 import logoDark from '../../assets/logo-dark.svg';
 
@@ -7,13 +8,7 @@ function BannerHeader() {
   const themeMode = useThemeMode();
   const theme = useTheme();
 
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = ('0' + (today.getMonth() + 1)).slice(-2);
-  const day = ('0' + today.getDate()).slice(-2);
-  const week = ['일', '월', '화', '수', '목', '금', '토'];
-  const dayOfWeek = week[today.getDay()];
-  const formattedDate = `${year}-${month}-${day} (${dayOfWeek})`;
+  const dateOfToday = formatDateWithDayofWeek();
 
   return (
     <div
@@ -28,7 +23,7 @@ function BannerHeader() {
           color: ${theme.color.text.label};
         `}
       >
-        {formattedDate}
+        {dateOfToday}
       </span>
       <div
         css={css`

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -1,0 +1,5 @@
+import Banner from './Banner';
+import BannerHeader from './BannerHeader';
+import BannerArticle from './BannerArticle';
+
+export { Banner, BannerHeader, BannerArticle };

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,6 +1,6 @@
 import { useTheme, css } from '@emotion/react';
-import Logo from './Logo';
-import ThemeToggleSwitch from './ThemeToggleSwitch';
+import Logo from '@components/Header/Logo';
+import ThemeToggleSwitch from '@components/Header/ThemeToggleSwitch';
 
 function Header() {
   const theme = useTheme();

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,6 +1,5 @@
 import { useTheme, css } from '@emotion/react';
-import Logo from '@components/Header/Logo';
-import ThemeToggleSwitch from '@components/Header/ThemeToggleSwitch';
+import { Logo, ThemeToggleSwitch } from '@components/Header';
 
 function Header() {
   const theme = useTheme();

--- a/src/components/Header/Logo.jsx
+++ b/src/components/Header/Logo.jsx
@@ -1,7 +1,7 @@
 import { useTheme, css } from '@emotion/react';
-import { useThemeMode } from '../../contexts/ThemeContext';
-import logoLight from '../../assets/logo-light.svg';
-import logoDark from '../../assets/logo-dark.svg';
+import { useThemeMode } from '@contexts/ThemeContext';
+import logoLight from '@assets/logo-light.svg';
+import logoDark from '@assets/logo-dark.svg';
 
 function Logo() {
   const themeMode = useThemeMode();

--- a/src/components/Header/ThemeToggleSwitch.jsx
+++ b/src/components/Header/ThemeToggleSwitch.jsx
@@ -1,6 +1,6 @@
 import { useTheme, css } from '@emotion/react';
 import { MdLightMode, MdDarkMode } from 'react-icons/md';
-import { useThemeMode, useSetThemeMode } from '../../contexts/ThemeContext';
+import { useThemeMode, useSetThemeMode } from '@contexts/ThemeContext';
 
 function ThemeToggleSwitch() {
   const themeMode = useThemeMode();

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,0 +1,5 @@
+import Header from './Header';
+import Logo from './Logo';
+import ThemeToggleSwitch from './ThemeToggleSwitch';
+
+export { Header, Logo, ThemeToggleSwitch };

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,0 +1,3 @@
+import Layout from './Layout';
+
+export { Layout };

--- a/src/components/common/Button/TranslateButton.jsx
+++ b/src/components/common/Button/TranslateButton.jsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
 import { MdGTranslate } from 'react-icons/md';
 
-function TranslateButton({ isTranslated, translate }) {
+function TranslateButton({ headline, isTranslated, translate }) {
   return (
     <button
-      onClick={() => translate()}
+      onClick={() => translate(headline)}
       css={css`
         display: flex;
         justify-content: center;

--- a/src/components/common/Translation/Translation.jsx
+++ b/src/components/common/Translation/Translation.jsx
@@ -1,4 +1,4 @@
-import TranslationDivider from './TranslationDivider';
+import TranslationDivider from '@common/Translation/TranslationDivider';
 
 function Translation({
   isTranslated,

--- a/src/components/common/Translation/Translation.jsx
+++ b/src/components/common/Translation/Translation.jsx
@@ -1,4 +1,4 @@
-import TranslationDivider from '@common/Translation/TranslationDivider';
+import { TranslationDivider } from '@components/common';
 
 function Translation({
   isTranslated,

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -1,0 +1,15 @@
+import ArticleLinkButton from './Button/ArticleLinkButton';
+import TranslateButton from './Button/TranslateButton';
+import ErrorMessage from './Error/ErrorMessage';
+import LoadingMessage from './Loading/LoadingMessage';
+import Translation from './Translation/Translation';
+import TranslationDivider from './Translation/TranslationDivider';
+
+export {
+  ArticleLinkButton,
+  TranslateButton,
+  ErrorMessage,
+  LoadingMessage,
+  Translation,
+  TranslationDivider,
+};

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,0 +1,9 @@
+export const BASE_URL = {
+  NYT: 'https://api.nytimes.com/svc',
+  GOOGLE_TRANSLATE: 'https://translation.googleapis.com/language/translate/v2',
+};
+
+export const NYT_REQUEST_URL = {
+  TOP_STORIES: '/topstories/v2/home.json', // 배너 기사
+  SEARCH: '/search/v2/articlesearch.json', // 메인 콘텐츠 기사 목록
+};

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,6 +1,6 @@
 import { useState, createContext, useContext } from 'react';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
-import { lightTheme, darkTheme } from '../styles/theme';
+import { lightTheme, darkTheme } from '@styles/theme';
 
 const ThemeModeContext = createContext();
 const SetThemeModeContext = createContext();

--- a/src/hooks/useFetchData.js
+++ b/src/hooks/useFetchData.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { axiosNYT } from '../apis/axios';
+import { axiosNYT } from '@apis/axios';
 
 const useFetchData = (requestURL) => {
   const [isFetchLoading, setIsFetchLoading] = useState(false);

--- a/src/hooks/useFetchData.js
+++ b/src/hooks/useFetchData.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { axiosNYT } from '../apis/axios';
+
+const useFetchData = (requestURL) => {
+  const [isFetchLoading, setIsFetchLoading] = useState(false);
+  const [fetchError, setFetchError] = useState(null);
+  const [fetchedData, setFetchedData] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsFetchLoading(true);
+      try {
+        const response = await axiosNYT.get(requestURL);
+        setFetchedData(response);
+      } catch (error) {
+        console.log(`기사 조회 중 오류 발생 | ${error}`);
+        setFetchError(error);
+      }
+      setIsFetchLoading(false);
+    };
+
+    fetchData();
+  }, []);
+
+  return [isFetchLoading, fetchError, fetchedData];
+};
+
+export default useFetchData;

--- a/src/hooks/useTranslate.js
+++ b/src/hooks/useTranslate.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { axiosGoogleTranslate } from '../apis/axios';
+
+const useTranslate = () => {
+  const [isTranslated, setIsTranslated] = useState(false);
+  const [isTranslateLoading, setIsTranslateLoading] = useState(false);
+  const [translateError, setTranslateError] = useState(null);
+  const [translationText, setTranslationText] = useState(null);
+
+  const translate = async (originalText) => {
+    if (!translationText) {
+      setIsTranslateLoading(true);
+      try {
+        const response = await axiosGoogleTranslate.post('/', {
+          q: originalText,
+        });
+        setTranslationText(response);
+        setIsTranslated(!isTranslated);
+      } catch (error) {
+        console.log(`기사 번역 중 오류 발생 | ${error}`);
+        setTranslateError(error);
+      }
+      setIsTranslateLoading(false);
+    } else {
+      // 이미 저장된 번역문이 있는 경우 API 재요청을 방지하고 토글 기능만 실행
+      setIsTranslated(!isTranslated);
+    }
+  };
+
+  return [
+    isTranslated,
+    isTranslateLoading,
+    translateError,
+    translationText,
+    translate,
+  ];
+};
+
+export default useTranslate;

--- a/src/hooks/useTranslate.js
+++ b/src/hooks/useTranslate.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { axiosGoogleTranslate } from '../apis/axios';
+import { axiosGoogleTranslate } from '@apis/axios';
 
 const useTranslate = () => {
   const [isTranslated, setIsTranslated] = useState(false);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.jsx';
+import App from '@/App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,5 +1,5 @@
-import { lightThemeColor, darkThemeColor } from './color';
-import typography from './typography';
+import { lightThemeColor, darkThemeColor } from '@styles/color';
+import typography from '@styles/typography';
 
 export const lightTheme = {
   color: lightThemeColor,

--- a/src/utils/formattingText.js
+++ b/src/utils/formattingText.js
@@ -1,0 +1,25 @@
+export const formatDateWithDayofWeek = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = ('0' + (today.getMonth() + 1)).slice(-2);
+  const day = ('0' + today.getDate()).slice(-2);
+  const week = ['일', '월', '화', '수', '목', '금', '토'];
+  const dayOfWeek = week[today.getDay()];
+
+  const formattedDate = `${year}-${month}-${day} (${dayOfWeek})`;
+
+  return formattedDate;
+};
+
+export const formatPublishDate = (date) => {
+  const formattedPublishDate = date.substring(0, 10);
+  return formattedPublishDate;
+};
+
+// 기사 section 이름의 첫 글자를 대문자로 변환(us인 경우 모든 글자를 대문자로 변환)
+export const capitalizeFirstLetter = (string) => {
+  const capitalizedFirstLetter = string.replace(/(\bus\b)|(\b\w)/g, (str) =>
+    str.toUpperCase()
+  );
+  return capitalizedFirstLetter;
+};

--- a/src/utils/getRandomInt.js
+++ b/src/utils/getRandomInt.js
@@ -1,0 +1,6 @@
+const getRandomInt = (max) => {
+  const randomInt = Math.floor(Math.random() * max);
+  return randomInt;
+};
+
+export default getRandomInt;

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,6 @@ export default defineConfig({
       { find: '@apis', replacement: '/src/apis' },
       { find: '@assets', replacement: '/src/assets' },
       { find: '@components', replacement: '/src/components' },
-      { find: '@common', replacement: '/src/components/common' },
       { find: '@constants', replacement: '/src/constants' },
       { find: '@contexts', replacement: '/src/contexts' },
       { find: '@hooks', replacement: '/src/hooks' },

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,18 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react({ jsxImportSource: '@emotion/react' })],
+  resolve: {
+    alias: [
+      { find: '@', replacement: '/src' },
+      { find: '@apis', replacement: '/src/apis' },
+      { find: '@assets', replacement: '/src/assets' },
+      { find: '@components', replacement: '/src/components' },
+      { find: '@common', replacement: '/src/components/common' },
+      { find: '@constants', replacement: '/src/constants' },
+      { find: '@contexts', replacement: '/src/contexts' },
+      { find: '@hooks', replacement: '/src/hooks' },
+      { find: '@styles', replacement: '/src/styles' },
+      { find: '@utils', replacement: '/src/utils' },
+    ],
+  },
 });


### PR DESCRIPTION
## Feature/refactor
- constants 폴더를 생성하여 공통적으로 사용되는 API 관련 값을 관리
- 뉴욕 타임스, 구글 번역 API 요청 중복 코드를 줄이기 위해 axios 인스턴스 및 useFetchData, useTranslate 커스텀 훅 생성 후 적용
- axios 응답 인터셉터를 이용하여 API 응답 결과 데이터 전처리
- BannerHeader의 오늘의 날짜 및 요일, BannerContent의 기사 section 이름 첫 글자 대문자화, Article의 기사 발행일 포맷, 랜덤 정수 생성 로직을 유틸리티 함수로 분리하여 utils 폴더에서 관리
- import문을 절대 경로로 설정
- Barrel export pattern으로 컴포넌트의 re-export를 관리하여 컴포넌트 import문을 간결하게 관리