### PR TITLE
[Feature/fix-header] fix section tab list located above header

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -14,6 +14,7 @@ function Header() {
         position: sticky;
         left: 0;
         top: 0;
+        z-index: 1000;
         transition: all 0.2s;
       `}
     >


### PR DESCRIPTION
### Feature/fix-header
- 헤더에 z-index 속성을 부여하여 섹션 탭 메뉴가 헤더 위에 위치하는 문제 해결