### PR TITLE
[Feature/fix-fetch-data] fix rendering error message instead of view more button

### DIFF
--- a/src/hooks/useFetchData.js
+++ b/src/hooks/useFetchData.js
@@ -22,6 +22,7 @@ const useFetchData = (
 
   const fetchData = useCallback(async () => {
     setIsFetchLoading(true);
+    setFetchError(null);
     try {
       const response = await axiosNYT.get(`${requestURL}?${searchParams}`);
       // 섹션 탭 panel 기사 목록을 조회하는 경우에만 응답 결과를 누적


### PR DESCRIPTION
### Feature/fix-fetch-data
- 데이터 조회 시 이전에 저장된 오류 정보를 초기화하여 '더 보기' 버튼 대신 오류 메시지가 나타나는 문제 해결