### PR TITLE
[Feature/fix-masonry] fix unsupported TypeScript in react-masonry-css library

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
-    "react-masonry-css": "^1.0.16",
     "react-responsive-masonry": "^2.3.0",
     "react-spinners": "^0.14.1",
     "zustand": "^4.5.5"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-masonry-css": "^1.0.16",
+    "react-responsive-masonry": "^2.3.0",
     "react-spinners": "^0.14.1",
     "zustand": "^4.5.5"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",
+    "@types/react-responsive-masonry": "^2.1.3",
     "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       react-icons:
         specifier: ^5.3.0
         version: 5.3.0(react@18.3.1)
-      react-masonry-css:
-        specifier: ^1.0.16
-        version: 1.0.16(react@18.3.1)
       react-responsive-masonry:
         specifier: ^2.3.0
         version: 2.3.0
@@ -1279,11 +1276,6 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-masonry-css@1.0.16:
-    resolution: {integrity: sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==}
-    peerDependencies:
-      react: '>=16.0.0'
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -2843,10 +2835,6 @@ snapshots:
       react: 18.3.1
 
   react-is@16.13.1: {}
-
-  react-masonry-css@1.0.16(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   react-refresh@0.14.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-masonry-css:
         specifier: ^1.0.16
         version: 1.0.16(react@18.3.1)
+      react-responsive-masonry:
+        specifier: ^2.3.0
+        version: 2.3.0
       react-spinners:
         specifier: ^0.14.1
         version: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1279,6 +1282,9 @@ packages:
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
+
+  react-responsive-masonry@2.3.0:
+    resolution: {integrity: sha512-ttb71B75qAfZ5q2CRLKRnCRO9V6p1Vkgw1C9wIeNaD2JpAxwCb1hUBI4Drqea9hNlvxxLpUkO0TRE5CLxqLY0A==}
 
   react-spinners@0.14.1:
     resolution: {integrity: sha512-2Izq+qgQ08HTofCVEdcAQCXFEYfqTDdfeDQJeo/HHQiQJD4imOicNLhkfN2eh1NYEWVOX4D9ok2lhuDB0z3Aag==}
@@ -2833,6 +2839,8 @@ snapshots:
       react: 18.3.1
 
   react-refresh@0.14.2: {}
+
+  react-responsive-masonry@2.3.0: {}
 
   react-spinners@0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@emotion/react':
         specifier: ^11.13.3
         version: 11.13.3(@types/react@18.3.5)(react@18.3.1)
+      '@types/react-responsive-masonry':
+        specifier: ^2.1.3
+        version: 2.1.3
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -523,6 +526,9 @@ packages:
 
   '@types/react-dom@18.3.0':
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
+
+  '@types/react-responsive-masonry@2.1.3':
+    resolution: {integrity: sha512-aOFUtv3QwNMmy0BgpQpvivQ/+vivMTB6ARrzf9eTSXsLzXpVnfEtjpHpSknYDnr8KaQmlgeauAj8E7wo/qMOTg==}
 
   '@types/react@18.3.5':
     resolution: {integrity: sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==}
@@ -1959,6 +1965,10 @@ snapshots:
   '@types/prop-types@15.7.12': {}
 
   '@types/react-dom@18.3.0':
+    dependencies:
+      '@types/react': 18.3.5
+
+  '@types/react-responsive-masonry@2.1.3':
     dependencies:
       '@types/react': 18.3.5
 

--- a/src/components/SectionTabs/ArticleList.tsx
+++ b/src/components/SectionTabs/ArticleList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import Masonry from 'react-masonry-css';
+import Masonry, { ResponsiveMasonry } from 'react-responsive-masonry';
 import { css } from '@emotion/react';
 import useActiveTabStore from '@stores/useActiveTabStore';
 import useFetchData from '@hooks/useFetchData';
@@ -45,30 +45,28 @@ function ArticleList() {
           padding: 1.5rem 0;
         `}
       >
-        <Masonry
-          breakpointCols={{
-            default: 2,
-            567: 1,
-          }}
-          css={css`
-            display: flex;
-            margin-bottom: 1.5rem;
-            > *:not(:last-child) {
-              margin-right: 1.25rem;
-            }
-            > * > *:not(:last-child) {
-              margin-bottom: 1.25rem;
-            }
-          `}
-        >
-          {articleList.map((article) => (
-            <Article
-              key={article._id}
-              publishDate={article.pub_date}
-              headline={article.headline.main}
-            />
-          ))}
-        </Masonry>
+        <ResponsiveMasonry columnsCountBreakPoints={{ 567: 1, 568: 2 }}>
+          <Masonry
+            css={css`
+              display: flex;
+              margin-bottom: 1.5rem;
+              > *:not(:last-child) {
+                margin-right: 1.25rem;
+              }
+              > * > *:not(:last-child) {
+                margin-bottom: 1.25rem;
+              }
+            `}
+          >
+            {articleList.map((article) => (
+              <Article
+                key={article._id}
+                publishDate={article.pub_date}
+                headline={article.headline.main}
+              />
+            ))}
+          </Masonry>
+        </ResponsiveMasonry>
         <ViewMoreButton
           isFetchLoading={isFetchLoading}
           fetchError={fetchError}


### PR DESCRIPTION
### Feature/fix-masonry
- react-masonry-css 라이브러리의 타입스크립트 미지원 문제로 인하여 대체 라이브러리 활용
- react-responsive-masonry 라이브러리로 그리드 라이아웃 디자인을 재구현